### PR TITLE
There may not be data for the key in the store, as WithClearDataStore…

### DIFF
--- a/Source/Mock/MockingBuilder.cs
+++ b/Source/Mock/MockingBuilder.cs
@@ -42,8 +42,9 @@ namespace LeanTest.Mock
                         theClass.GetTypeInfo().GetDeclaredMethod(PreBuildMethod).Invoke(mock, null);
                     }
 
-                    foreach (object data in _dataStore.TypedData[mockDelegatesForType.Key])
-                        theClass.GetTypeInfo().GetDeclaredMethod(WithDataMethod).Invoke(mock, new[] { data });
+                    if (_dataStore.TypedData.ContainsKey(mockDelegatesForType.Key))
+                        foreach (object data in _dataStore.TypedData[mockDelegatesForType.Key])
+                            theClass.GetTypeInfo().GetDeclaredMethod(WithDataMethod).Invoke(mock, new[] { data });
 
                     theClass.GetTypeInfo().GetDeclaredMethod(BuildMethod).Invoke(mock, new object[] { mockDelegatesForType.Key });
 


### PR DESCRIPTION
… could have cleared it!