### PR TITLE
Embed PDB into assemblies

### DIFF
--- a/Source/Core/Core.csproj
+++ b/Source/Core/Core.csproj
@@ -16,13 +16,11 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <AssemblyVersion>$(appveyor_build_version)</AssemblyVersion>
     <FileVersion>$(appveyor_build_version)</FileVersion>
-  </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>LeanTest.Core.xml</DocumentationFile>
-  </PropertyGroup>
+    <!-- Embed PDB inside dll -->
+    <DebugType>embedded</DebugType>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\LeanTest.Core.xml</DocumentationFile>
+    <!-- Generate XML doc for consumers -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 </Project>

--- a/Source/MSTest/MSTest.csproj
+++ b/Source/MSTest/MSTest.csproj
@@ -17,10 +17,12 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <AssemblyVersion>$(appveyor_build_version)</AssemblyVersion>
     <FileVersion>$(appveyor_build_version)</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\LeanTest.MSTest.xml</DocumentationFile>
+    
+    <!-- Embed PDB inside dll -->
+    <DebugType>embedded</DebugType>
+    
+    <!-- Generate XML doc for consumers -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Currently the nuget packages does not contain debug information (PDB files). This PR enables use of embedded PDB. Additionally are the `DocumentationFile` properties replaced with `GenerateDocumentationFile`. 