### PR TITLE
Allow registering LeanTest attributes via TestContext

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# top-most EditorConfig file
+root = true
+
+[*.cs]
+indent_style = tab
+indent_size = 4
+
+
+# Spaces in XML files
+[*.{props,targets,config,nuspec,csproj,proj}]
+indent_style = space
+indent_size = 2

--- a/Source/LeanTest.sln
+++ b/Source/LeanTest.sln
@@ -29,6 +29,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSTest", "MSTest\MSTest.csp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSTest.Examples.MsTest", "MSTest.Examples.MsTest\MSTest.Examples.MsTest.csproj", "{BC15DD45-522D-4086-B7D1-63806896D417}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{67FE6255-20F5-443D-979A-8839C6666C9B}"
+	ProjectSection(SolutionItems) = preProject
+		..\.editorconfig = ..\.editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Source/MSTest/ContextBuilderExtensions.cs
+++ b/Source/MSTest/ContextBuilderExtensions.cs
@@ -6,54 +6,40 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LeanTest.MSTest
 {
-    /// <summary>
-    /// Adds support for adding test data in Json format.
-    /// </summary>
-    public static class ContextBuilderExtensions
-    {
+	/// <summary>
+	/// Adds support for adding test data in Json format.
+	/// </summary>
+	public static class ContextBuilderExtensions
+	{
 		/// <summary>Registers an intend to use the <c>TestScenarioId</c> attribute on test methods.</summary>
 		/// <remarks>This causes scenario IDs to be written to the test log (.trx-file).</remarks>
 		public static ContextBuilder RegisterScenarioId(this ContextBuilder theContextBuilder, TestContext testContext, Assembly assembly = null)
-	    {
-	        assembly = assembly ?? Assembly.GetCallingAssembly();
-		    MethodInfo[] methods = assembly.GetTypes()
-			    .SelectMany(t => t.GetMethods())
-			    .Where(m => m.GetCustomAttributes(typeof(TestScenarioIdAttribute), false).Length > 0)
-			    .Where(m => m.Name == testContext.TestName)
-			    .ToArray();
+		{
+			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
 
-		    foreach (MethodInfo methodInfo in methods)
-		        foreach (TestScenarioIdAttribute testScenarioIdAttribute in methodInfo.GetCustomAttributes(typeof(TestScenarioIdAttribute), false))
-			        Console.WriteLine($@"{TestScenarioIdAttribute.Prefix}{testScenarioIdAttribute?.Value}{TestScenarioIdAttribute.Postfix}");
+			testContext.RegisterScenarioId(assembly);
+			return theContextBuilder;
+		}
 
-		    return theContextBuilder;
-	    }
 		/// <summary>Registers an intend to use the LeanTest attribute on test methods.</summary>
 		/// <remarks>This causes scenario IDs and tags to be written to the test log (.trx-file).</remarks>
 		public static ContextBuilder RegisterTags(this ContextBuilder theContextBuilder, TestContext testContext, Assembly assembly = null)
-	    {
-		    assembly = assembly ?? Assembly.GetCallingAssembly();
-		    MethodInfo[] methods = assembly.GetTypes()
-			    .SelectMany(t => t.GetMethods())
-			    .Where(m => m.GetCustomAttributes(typeof(TestTagAttribute), false).Length > 0)
-			    .Where(m => m.Name == testContext.TestName)
-			    .ToArray();
+		{
+			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
 
-		    foreach (MethodInfo methodInfo in methods)
-		        foreach (TestTagAttribute testTagAttribute in methodInfo.GetCustomAttributes(typeof(TestTagAttribute), false))
-			        Console.WriteLine($@"{TestTagAttribute.Prefix}{testTagAttribute?.Value}{TestTagAttribute.Postfix}");
+			testContext.RegisterTags(assembly);
+			return theContextBuilder;
+		}
 
-		    return theContextBuilder;
-	    }
 		/// <summary>Registers an intend to use the LeanTest attribute on test methods.</summary>
 		/// <remarks>This causes scenario IDs and tags to be written to the test log (.trx-file).</remarks>
 		// TODO: Use the builder pattern - defer writing until build!?
 		public static ContextBuilder RegisterAttributes(this ContextBuilder theContextBuilder, TestContext testContext, Assembly assembly = null)
-        {
-            assembly = assembly ?? Assembly.GetCallingAssembly();
-            return theContextBuilder
-                .RegisterScenarioId(testContext, assembly)
-                .RegisterTags(testContext, assembly);
-        }
-    }
+		{
+			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
+
+			testContext.RegisterAttributes(assembly);
+			return theContextBuilder;
+		}
+	}
 }

--- a/Source/MSTest/TestContextExtensions.cs
+++ b/Source/MSTest/TestContextExtensions.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace LeanTest.MSTest
+{
+	/// <summary>
+	/// Extension methods for MS Tests TestContext.
+	/// </summary>
+	public static class TestContextExtensions
+	{
+		/// <summary>Registers an intend to use the <c>TestScenarioId</c> attribute on test methods.</summary>
+		/// <remarks>This causes scenario IDs to be written to the test log (.trx-file).</remarks>
+		public static TestContext RegisterScenarioId(this TestContext testContext, Assembly assembly = null)
+		{
+			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
+
+			assembly = assembly ?? Assembly.GetCallingAssembly();
+			MethodInfo[] methods = assembly.GetTypes()
+				.SelectMany(t => t.GetMethods())
+				.Where(m => m.GetCustomAttributes(typeof(TestScenarioIdAttribute), false).Length > 0)
+				.Where(m => m.Name == testContext.TestName)
+				.ToArray();
+
+			foreach (MethodInfo methodInfo in methods)
+				foreach (TestScenarioIdAttribute testScenarioIdAttribute in methodInfo.GetCustomAttributes(typeof(TestScenarioIdAttribute), false))
+					Console.WriteLine($@"{TestScenarioIdAttribute.Prefix}{testScenarioIdAttribute?.Value}{TestScenarioIdAttribute.Postfix}");
+
+			return testContext;
+		}
+
+		/// <summary>Registers an intend to use the LeanTest attribute on test methods.</summary>
+		/// <remarks>This causes scenario IDs and tags to be written to the test log (.trx-file).</remarks>
+		public static TestContext RegisterTags(this TestContext testContext, Assembly assembly = null)
+		{
+			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
+
+			assembly = assembly ?? Assembly.GetCallingAssembly();
+			MethodInfo[] methods = assembly.GetTypes()
+				.SelectMany(t => t.GetMethods())
+				.Where(m => m.GetCustomAttributes(typeof(TestTagAttribute), false).Length > 0)
+				.Where(m => m.Name == testContext.TestName)
+				.ToArray();
+
+			foreach (MethodInfo methodInfo in methods)
+				foreach (TestTagAttribute testTagAttribute in methodInfo.GetCustomAttributes(typeof(TestTagAttribute), false))
+					Console.WriteLine($@"{TestTagAttribute.Prefix}{testTagAttribute?.Value}{TestTagAttribute.Postfix}");
+
+			return testContext;
+		}
+
+		/// <summary>Registers an intend to use the LeanTest attribute on test methods.</summary>
+		/// <remarks>This causes scenario IDs and tags to be written to the test log (.trx-file).</remarks>
+		public static TestContext RegisterAttributes(this TestContext testContext, Assembly assembly = null)
+		{
+			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
+
+			assembly = assembly ?? Assembly.GetCallingAssembly();
+			return testContext
+				.RegisterScenarioId(assembly)
+				.RegisterTags(assembly);
+		}
+	}
+}


### PR DESCRIPTION
Move `RegisterScenarioId`, `RegisterTags`, and `RegisterAttributes` methods to extensions on MS Test's `TestContext` as they only operate on that. The existing extension methods still exists but forwards to TestContext methods.

Additionally have I added an `.editorconfig` file to control indentation. It’s configured to follow existing cs files in repo. 