### PR TITLE
Use TestContext.FullyQualifiedTestClassName to find type instead of calling assembly.

### DIFF
--- a/Source/MSTest/ContextBuilderExtensions.cs
+++ b/Source/MSTest/ContextBuilderExtensions.cs
@@ -13,32 +13,32 @@ namespace LeanTest.MSTest
 	{
 		/// <summary>Registers an intend to use the <c>TestScenarioId</c> attribute on test methods.</summary>
 		/// <remarks>This causes scenario IDs to be written to the test log (.trx-file).</remarks>
-		public static ContextBuilder RegisterScenarioId(this ContextBuilder theContextBuilder, TestContext testContext, Assembly assembly = null)
+		public static ContextBuilder RegisterScenarioId(this ContextBuilder theContextBuilder, TestContext testContext)
 		{
 			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
 
-			testContext.RegisterScenarioId(assembly);
+			testContext.RegisterScenarioId();
 			return theContextBuilder;
 		}
 
 		/// <summary>Registers an intend to use the LeanTest attribute on test methods.</summary>
 		/// <remarks>This causes scenario IDs and tags to be written to the test log (.trx-file).</remarks>
-		public static ContextBuilder RegisterTags(this ContextBuilder theContextBuilder, TestContext testContext, Assembly assembly = null)
+		public static ContextBuilder RegisterTags(this ContextBuilder theContextBuilder, TestContext testContext)
 		{
 			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
 
-			testContext.RegisterTags(assembly);
+			testContext.RegisterTags();
 			return theContextBuilder;
 		}
 
 		/// <summary>Registers an intend to use the LeanTest attribute on test methods.</summary>
 		/// <remarks>This causes scenario IDs and tags to be written to the test log (.trx-file).</remarks>
 		// TODO: Use the builder pattern - defer writing until build!?
-		public static ContextBuilder RegisterAttributes(this ContextBuilder theContextBuilder, TestContext testContext, Assembly assembly = null)
+		public static ContextBuilder RegisterAttributes(this ContextBuilder theContextBuilder, TestContext testContext)
 		{
 			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
 
-			testContext.RegisterAttributes(assembly);
+			testContext.RegisterAttributes();
 			return theContextBuilder;
 		}
 	}

--- a/Source/MSTest/TestContextExtensions.cs
+++ b/Source/MSTest/TestContextExtensions.cs
@@ -14,54 +14,48 @@ namespace LeanTest.MSTest
 	{
 		/// <summary>Registers an intend to use the <c>TestScenarioId</c> attribute on test methods.</summary>
 		/// <remarks>This causes scenario IDs to be written to the test log (.trx-file).</remarks>
-		public static TestContext RegisterScenarioId(this TestContext testContext, Assembly assembly = null)
+		public static TestContext RegisterScenarioId(this TestContext testContext)
 		{
 			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
 
-			assembly = assembly ?? Assembly.GetCallingAssembly();
-			MethodInfo[] methods = assembly.GetTypes()
-				.SelectMany(t => t.GetMethods())
-				.Where(m => m.GetCustomAttributes(typeof(TestScenarioIdAttribute), false).Length > 0)
-				.Where(m => m.Name == testContext.TestName)
-				.ToArray();
-
-			foreach (MethodInfo methodInfo in methods)
-				foreach (TestScenarioIdAttribute testScenarioIdAttribute in methodInfo.GetCustomAttributes(typeof(TestScenarioIdAttribute), false))
-					Console.WriteLine($@"{TestScenarioIdAttribute.Prefix}{testScenarioIdAttribute?.Value}{TestScenarioIdAttribute.Postfix}");
+			foreach (var testScenarioIdAttribute in GetAttributesForTestMethod<TestScenarioIdAttribute>(testContext))
+			{
+				Console.WriteLine($@"{TestScenarioIdAttribute.Prefix}{testScenarioIdAttribute?.Value}{TestScenarioIdAttribute.Postfix}");
+			}
 
 			return testContext;
 		}
 
 		/// <summary>Registers an intend to use the LeanTest attribute on test methods.</summary>
 		/// <remarks>This causes scenario IDs and tags to be written to the test log (.trx-file).</remarks>
-		public static TestContext RegisterTags(this TestContext testContext, Assembly assembly = null)
+		public static TestContext RegisterTags(this TestContext testContext)
 		{
 			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
 
-			assembly = assembly ?? Assembly.GetCallingAssembly();
-			MethodInfo[] methods = assembly.GetTypes()
-				.SelectMany(t => t.GetMethods())
-				.Where(m => m.GetCustomAttributes(typeof(TestTagAttribute), false).Length > 0)
-				.Where(m => m.Name == testContext.TestName)
-				.ToArray();
-
-			foreach (MethodInfo methodInfo in methods)
-				foreach (TestTagAttribute testTagAttribute in methodInfo.GetCustomAttributes(typeof(TestTagAttribute), false))
-					Console.WriteLine($@"{TestTagAttribute.Prefix}{testTagAttribute?.Value}{TestTagAttribute.Postfix}");
+			foreach (var testTagAttribute in GetAttributesForTestMethod<TestTagAttribute>(testContext))
+			{
+				Console.WriteLine($@"{TestTagAttribute.Prefix}{testTagAttribute?.Value}{TestTagAttribute.Postfix}");
+			}
 
 			return testContext;
 		}
 
 		/// <summary>Registers an intend to use the LeanTest attribute on test methods.</summary>
 		/// <remarks>This causes scenario IDs and tags to be written to the test log (.trx-file).</remarks>
-		public static TestContext RegisterAttributes(this TestContext testContext, Assembly assembly = null)
+		public static TestContext RegisterAttributes(this TestContext testContext)
 		{
 			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
 
-			assembly = assembly ?? Assembly.GetCallingAssembly();
 			return testContext
-				.RegisterScenarioId(assembly)
-				.RegisterTags(assembly);
+				.RegisterScenarioId()
+				.RegisterTags();
+		}
+
+		private static IEnumerable<TAttributeType> GetAttributesForTestMethod<TAttributeType>(TestContext testContext)
+		{
+			var testClassType = Type.GetType(testContext.FullyQualifiedTestClassName, throwOnError: true);
+			var testMethod = testClassType.GetMethod(testContext.TestName) ?? throw new Exception($"Unable to find test method {testContext.TestName} on type {testContext.FullyQualifiedTestClassName}");
+			return testMethod.GetCustomAttributes(typeof(TAttributeType), inherit: false).Cast<TAttributeType>();
 		}
 	}
 }


### PR DESCRIPTION
When registering attributes the use of `Assembly.GetCallingAssembly()` may not be the test assembly which we expect because the JIT have inlined some methods. Instead we should rely on `TestContext.FullyQualifiedTestClassName` to get the type implementing the test method.