### PR TITLE
Allow registering attributes via TestContext

### DIFF
--- a/Source/MSTest.Examples.MsTest/TestRegisterAttributesUsingTestContext.cs
+++ b/Source/MSTest.Examples.MsTest/TestRegisterAttributesUsingTestContext.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using LeanTest.MSTest;
+
+namespace MSTest.Examples.MsTest
+{
+	[TestClass]
+	public class TestRegisterAttributesUsingTestContext
+	{
+		// Populated by MS Test
+		public TestContext TestContext { get; set; }
+
+		[TestMethod]
+		public void RegisterAttributesMustWorkWhenUsingTextContext()
+		{
+			this.TestContext.RegisterAttributes();
+			Assert.IsTrue(true);
+		}
+
+		[TestMethod]
+		public void RegisterAttributesMustWorkWhenUsingTextContextAndPassingAssembly()
+		{
+			this.TestContext.RegisterAttributes(System.Reflection.Assembly.GetExecutingAssembly());
+			Assert.IsTrue(true);
+		}
+	}
+}

--- a/Source/MSTest/TestContextExtensions.cs
+++ b/Source/MSTest/TestContextExtensions.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace LeanTest.MSTest
+{
+	/// <summary>
+	/// Extension methods for MS Tests TestContext.
+	/// </summary>
+	public static class TestContextExtensions
+	{
+		/// <summary>Registers an intend to use the <c>TestScenarioId</c> attribute on test methods.</summary>
+		/// <param name="testContext"></param>
+		/// <param name="assemblyContainingTest">Assembly containing the test for which to register scenario id for</param>
+		/// <remarks>This causes scenario IDs to be written to the test log (.trx-file).</remarks>
+		public static TestContext RegisterScenarioId(this TestContext testContext, Assembly assemblyContainingTest)
+		{
+			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
+			if (assemblyContainingTest == null) throw new ArgumentNullException(nameof(assemblyContainingTest));
+
+			foreach (var testScenarioIdAttribute in GetAttributesForTestMethod<TestScenarioIdAttribute>(testContext, assemblyContainingTest))
+			{
+				Console.WriteLine($@"{TestScenarioIdAttribute.Prefix}{testScenarioIdAttribute?.Value}{TestScenarioIdAttribute.Postfix}");
+			}
+
+			return testContext;
+		}
+
+		/// <summary>Registers an intend to use the LeanTest attribute on test methods.</summary>
+		/// <param name="testContext"></param>
+		/// <param name="assemblyContainingTest">Assembly containing the test for which to register tags for</param>
+		/// <remarks>This causes scenario IDs and tags to be written to the test log (.trx-file).</remarks>
+		public static TestContext RegisterTags(this TestContext testContext, Assembly assemblyContainingTest)
+		{
+			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
+			if (assemblyContainingTest == null) throw new ArgumentNullException(nameof(assemblyContainingTest));
+
+			foreach (var testTagAttribute in GetAttributesForTestMethod<TestTagAttribute>(testContext, assemblyContainingTest))
+			{
+				Console.WriteLine($@"{TestTagAttribute.Prefix}{testTagAttribute?.Value}{TestTagAttribute.Postfix}");
+			}
+
+			return testContext;
+		}
+
+		/// <summary>Registers an intend to use the LeanTest attribute on test methods.</summary>
+		/// <param name="testContext"></param>
+		/// <param name="assemblyContainingTest">Assembly containing the test for which to register attributes for. If not passed, GetCallingAssembly will be used. </param>
+		/// <remarks>This causes scenario IDs and tags to be written to the test log (.trx-file).</remarks>
+		[System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+		public static TestContext RegisterAttributes(this TestContext testContext, Assembly assemblyContainingTest = null)
+		{
+			if (testContext == null) throw new ArgumentNullException(nameof(testContext));
+
+			// We assume the calling assembly is the assembly containing the test for which we need to register attributes.
+			// For this to work we need to make sure JIT doesn't inline this method, so we use MethodImplOptions.NoInlining
+			var assembly = assemblyContainingTest ?? Assembly.GetCallingAssembly();
+
+			return testContext
+				.RegisterScenarioId(assembly)
+				.RegisterTags(assembly);
+		}
+
+		private static IEnumerable<TAttributeType> GetAttributesForTestMethod<TAttributeType>(TestContext testContext, Assembly assemblyContainingTest)
+		{
+			var testClassType = assemblyContainingTest.GetType(testContext.FullyQualifiedTestClassName);
+			
+			var testMethod = testClassType.GetMethod(testContext.TestName) ?? throw new Exception($"Unable to find test method {testContext.TestName} on type {testContext.FullyQualifiedTestClassName}");
+			return testMethod.GetCustomAttributes(typeof(TAttributeType), inherit: false).Cast<TAttributeType>();
+		}
+	}
+}


### PR DESCRIPTION
Now that #25 was reverted, this PR re-adds extension methods for MS Test `TestContext` to register attributes. It's completely self-contained - no changes made to extension methods on ContextBuilder.