### PR TITLE
Update Lean_Test_Coding_Guidelines.html

### DIFF
--- a/docs/Lean_Test_Coding_Guidelines.html
+++ b/docs/Lean_Test_Coding_Guidelines.html
@@ -379,7 +379,8 @@ and <code>IMockForData&lt;AccountList&gt;</code>.</p>
     where TInterface: class
 {
     container.AddSingleton&lt;TImplementation&gt;();
-    container.AddSingleton&lt;TInterface&gt;(x =&gt; x.GetRequiredService&lt;TImplementation&gt;());
+    if (typeof(TInterface) != typeof(TImplementation))
+    	container.AddSingleton&lt;TInterface&gt;(x =&gt; x.GetRequiredService&lt;TImplementation&gt;());
     container.AddSingleton&lt;IMockForData&lt;TData&gt;&gt;(x =&gt; x.GetRequiredService&lt;TImplementation&gt;());
 }
 </code></pre>


### PR DESCRIPTION
It is not unusual to register services on their own type.

Calling RegisterMockForData<TInterface, TImplementation, TData> when TInterface and TImplementation are the same hung a test during contextBuilder.Build.

Fixed the documentation for RegisterMockForData by only registering the singleton on TInterface if it is different from TImplementation.