### PR TITLE
Support for AsyncDispose

### DIFF
--- a/AspNetCore/AspNetCoreExtensions.cs
+++ b/AspNetCore/AspNetCoreExtensions.cs
@@ -143,7 +143,7 @@ namespace LeanTest
         {
             private WebApplicationFactory<T> _factory;
             private TestServer _testServer;
-            private HttpClient _client;			
+            private HttpClient _client;
 
             public FactoryWrapper(Func<WebApplicationFactory<T>> factoryFactory)
             {

--- a/AspNetCore/AspNetCoreExtensions.cs
+++ b/AspNetCore/AspNetCoreExtensions.cs
@@ -130,7 +130,6 @@ namespace LeanTest
 
             public void Dispose()
             {
-                (_testServer?.Host?.Services as IDisposable)?.Dispose();
                 _testServer?.Dispose();
                 _testServer = null;
                 _client?.Dispose();
@@ -144,7 +143,7 @@ namespace LeanTest
         {
             private WebApplicationFactory<T> _factory;
             private TestServer _testServer;
-            private HttpClient _client;
+            private HttpClient _client;			
 
             public FactoryWrapper(Func<WebApplicationFactory<T>> factoryFactory)
             {
@@ -158,7 +157,6 @@ namespace LeanTest
 
             public void Dispose()
             {
-                (_factory?.Services as IDisposable)?.Dispose();
                 _factory?.Dispose();
                 _factory = null;
             }

--- a/LeanTest.sln
+++ b/LeanTest.sln
@@ -45,6 +45,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xunit", "Source\xUnit\Xunit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DI.DotNetCore", "Source\DI.DotNetCore\DI.DotNetCore.csproj", "{5317582F-F808-4ADF-B46A-BDBBE33984CD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCore.L0Tests", "Source\AspNetCore.L0Tests\AspNetCore.L0Tests.csproj", "{7F7805E9-BD15-49B6-B376-47EBA9CA28B3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +85,10 @@ Global
 		{5317582F-F808-4ADF-B46A-BDBBE33984CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5317582F-F808-4ADF-B46A-BDBBE33984CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5317582F-F808-4ADF-B46A-BDBBE33984CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F7805E9-BD15-49B6-B376-47EBA9CA28B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F7805E9-BD15-49B6-B376-47EBA9CA28B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F7805E9-BD15-49B6-B376-47EBA9CA28B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F7805E9-BD15-49B6-B376-47EBA9CA28B3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/AspNetCore.L0Tests/AspNetCore.L0Tests.csproj
+++ b/Source/AspNetCore.L0Tests/AspNetCore.L0Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.24" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="MSTest" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\AspNetCore\AspNetCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/AspNetCore.L0Tests/AsyncDisposableTests.cs
+++ b/Source/AspNetCore.L0Tests/AsyncDisposableTests.cs
@@ -1,0 +1,28 @@
+﻿using AspNetCore.L0Tests.Helpers;
+using LeanTest.Core.ExecutionHandling;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+
+namespace AspNetCore.L0Tests
+{
+	[TestClass]
+	public class AsyncDisposableTests
+	{
+		private ContextBuilder _contextBuilder;
+
+		[TestInitialize]
+		public void TestInitialize()
+		{
+			_contextBuilder = ContextBuilderFactory.CreateContextBuilder();
+		}
+
+		[TestMethod]
+		[DataRow(1)]
+		[DataRow(2)]
+		public async Task AsyncDisposableServiceIsDisposedAfterTest(int _)
+		{
+			// We just need to resolve the service to have it tracked by the context builder and disposed at the end of the test
+			_contextBuilder.GetInstance<DelayedAsyncDisposableService>();
+		}
+	}
+}

--- a/Source/AspNetCore.L0Tests/Helpers/DelayedAsyncDisposableService.cs
+++ b/Source/AspNetCore.L0Tests/Helpers/DelayedAsyncDisposableService.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace AspNetCore.L0Tests.Helpers
+{
+	public sealed class DelayedAsyncDisposableService : IAsyncDisposable
+	{
+		public async ValueTask DisposeAsync()
+		{
+			//forces ValueTask to be asynchronous and not be immediately completed
+			await Task.Yield();
+		}
+	}
+}

--- a/Source/AspNetCore.L0Tests/TestSetup/AssemblyInitializer.cs
+++ b/Source/AspNetCore.L0Tests/TestSetup/AssemblyInitializer.cs
@@ -1,0 +1,66 @@
+﻿using AspNetCore.L0Tests.TestSetup.IoC;
+using LeanTest;
+using LeanTest.Core.ExecutionHandling;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Reflection;
+
+namespace AspNetCore.L0Tests.TestSetup
+{
+	[TestClass]
+	public static class AssemblyInitializer
+	{
+		[AssemblyInitialize]
+		public static void AssemblyInitialize(TestContext _)
+		{
+			static WebApplicationFactory<EntryPoint> FactoryFactory()
+			{
+				WebApplicationFactory<EntryPoint> factory = new WebApplicationFactory<EntryPoint>();
+				factory = factory.WithWebHostBuilder(
+					builder =>
+					{
+						// Set the content root to the test assembly's directory
+						var assemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+						builder.UseContentRoot(assemblyPath ?? Directory.GetCurrentDirectory());
+						builder.ConfigureTestServices(L0CompositionRootForTest.Initialize);
+					});
+
+				return factory;
+			}
+			AspNetCoreContextBuilderFactory.Initialize(FactoryFactory, provider => new IoCContainer(provider));
+		}
+
+		[AssemblyCleanup]
+		public static void AssemblyCleanup()
+		{
+			ContextBuilderFactory.Cleanup();
+		}
+
+		public class EntryPoint
+		{
+			public static void Main(string[] args)
+			{
+				CreateHostBuilder(args).Build().Run();
+			}
+
+			public static IHostBuilder CreateHostBuilder(string[] args) =>
+				Host.CreateDefaultBuilder(args)
+					.ConfigureWebHostDefaults(webBuilder =>
+					{
+						webBuilder.Configure(app =>
+						{
+							app.Map("/test", builder => builder.Run(async context =>
+							{
+								await context.Response.WriteAsync("Hello world");
+							}));
+						});
+					});
+		}
+	}
+}

--- a/Source/AspNetCore.L0Tests/TestSetup/IoC/IoCContainer.cs
+++ b/Source/AspNetCore.L0Tests/TestSetup/IoC/IoCContainer.cs
@@ -1,0 +1,20 @@
+﻿using LeanTest.Core.ExecutionHandling;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace AspNetCore.L0Tests.TestSetup.IoC
+{
+	internal class IoCContainer : IIocContainer
+	{
+		private readonly IServiceProvider _serviceProvider;
+
+		public IoCContainer(IServiceProvider serviceProvider) => _serviceProvider = serviceProvider;
+
+		public T Resolve<T>() where T : class => _serviceProvider.GetRequiredService<T>();
+
+		public T TryResolve<T>() where T : class => _serviceProvider.GetService<T>();
+
+		public IEnumerable<T> TryResolveAll<T>() where T : class => _serviceProvider.GetServices<T>();
+	}
+}

--- a/Source/AspNetCore.L0Tests/TestSetup/IoC/L0CompositionRootForTest.cs
+++ b/Source/AspNetCore.L0Tests/TestSetup/IoC/L0CompositionRootForTest.cs
@@ -1,0 +1,13 @@
+﻿using AspNetCore.L0Tests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AspNetCore.L0Tests.TestSetup.IoC
+{
+	public static class L0CompositionRootForTest
+	{
+		public static void Initialize(IServiceCollection services)
+		{
+			services.AddSingleton<DelayedAsyncDisposableService>();
+		}		
+	}
+}


### PR DESCRIPTION
Some registered services might implement IAsyncDisposable, which can cause an exception if Dispose is invoked directly on IServiceProvider. Fortunately, TestClient or HostBuilder can manage service disposal, including any asynchronous disposals, by using DisposeAsync. Therefore, it’s unnecessary to call Dispose directly on IServiceProvider. A test has been added to ensure this functionality works as expected.